### PR TITLE
avoid unspecified bias

### DIFF
--- a/src/santa/simulator/SimulatorParser.java
+++ b/src/santa/simulator/SimulatorParser.java
@@ -1363,6 +1363,10 @@ public class SimulatorParser {
 					throw new ParseException("specify either <" + TRANSITION_BIAS + "> or <" + RATE_BIAS + ">, but not both.");
 				}
 
+				if (transitionBias == -1 && rateBiases == null) {
+					throw new ParseException("must specify one of <" + TRANSITION_BIAS + "> or <" + RATE_BIAS + ">.");
+				}
+
 				// insert and delete probability default to 0 if left unspecificed.
 				if (insertProb < 0) insertProb = 0;
 				if (deleteProb < 0) deleteProb = 0;


### PR DESCRIPTION
- require one of <transitionBias> or <rateBias> elements in
  nucleotideMutator element when parsing config file.

I noticed that a simulation starting with 'AAAAAA' genomes hat I was getting only A -> C substitutions, and no other A -> [GT] transitions.  I track the problem down in a config file using `<nucleotideMutator>` without `<rateBias>`  and without `<transitionBias>`, e.g.
```
  <mutator>
    <nucleotideMutator>
      <mutationRate>$mutationrate</mutationRate>
    </nucleotideMutator>
  </mutator>
```

When this happened transition bias remains undefined and the only transversion substitutions are allowed.   This was a surprising result as I expected to see unbiased substitutions since the config did not specify a bias.

There are two fixes for this. (1) provide rational default for when transition bias is not specified, or (2) always require transition bias or rate bias to be supplied.  I chose (2) because the examples/santa.xsd file already requires one of  <transitionBias> or <rateBias>.   Technically my config file was misspecified but the parser was not complaining.  Now it will.


