### PR TITLE
make initial populations reflect inoculum

### DIFF
--- a/src/santa/simulator/genomes/SimpleGenePool.java
+++ b/src/santa/simulator/genomes/SimpleGenePool.java
@@ -69,7 +69,7 @@ public class SimpleGenePool extends BaseGenePool {
 
             return newGenome;
         } else {
-            genome.setFrequency(genome.getFrequency() + 1);
+            genome.incrementFrequency();
             fitnessFunction.updateLogFitness(genome);
             return genome;
         }

--- a/src/santa/simulator/genomes/SimpleSequence.java
+++ b/src/santa/simulator/genomes/SimpleSequence.java
@@ -15,9 +15,14 @@ import java.util.SortedSet;
  * A genomic mutable sequence.
  */
 public final class SimpleSequence implements Sequence {
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+
 	/*
-		 * Internal representation: every byte corresponds to a nucleotide.
-		 */
+	 * Internal representation: every byte corresponds to a nucleotide.
+	 */
 	private byte states[];
 
 	/**
@@ -70,6 +75,35 @@ public final class SimpleSequence implements Sequence {
 		states = new byte[length];
 
 		copyNucleotides(0, other, start, length);
+	}
+
+	/* Override hashCode() and equals() so Sequence instamces can be
+	   used as keys in hash collections,
+	   e.g. Population::initialize().
+	*/
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Arrays.hashCode(states);
+		return result;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SimpleSequence other = (SimpleSequence) obj;
+		if (!Arrays.equals(states, other.states))
+			return false;
+		return true;
 	}
 
 	public Sequence getSubSequence(int start, int length) {

--- a/src/santa/simulator/population/Population.java
+++ b/src/santa/simulator/population/Population.java
@@ -77,7 +77,7 @@ public abstract class Population {
             // ancestors[0] = genePool.createGenome(sequence);
         }
 
-        if (inoculum.size() <= initialPopulationSize) {
+        if (ancestors.length >= initialPopulationSize) {
             // Allow experimenting with deterministic initial populations.
             // If the inoculum is the same size or greater than the population,
             // use the supplied inoculum as the complete population without any random selection.

--- a/src/santa/simulator/population/Population.java
+++ b/src/santa/simulator/population/Population.java
@@ -11,7 +11,9 @@ package santa.simulator.population;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Set;
+import java.util.Map;
 
 import santa.simulator.NotImplementedException;
 import santa.simulator.Random;
@@ -32,16 +34,16 @@ import santa.simulator.selectors.Selector;
  *         Time: 9:12:27 AM
  */
 public abstract class Population {
-    
+
     public int getPopulationSize() {
         return getCurrentGeneration().size();
     }
-    
+
     public Population(GenePool genePool, Selector selector, Phylogeny phylogeny) {
         this.phylogeny = phylogeny;
         this.genePool = genePool;
         this.selector = selector;
-        
+
         lastGeneration = new ArrayList<Virus>();
         currentGeneration = new ArrayList<Virus>();
     }
@@ -53,11 +55,18 @@ public abstract class Population {
         currentGeneration.clear();
         lastGeneration.clear();
         if (inoculum.size() > 0) {
-            // inoculum has sequences
+            //  Build `ancestors` array holding Genomes corresponding to each entry in the
+            // inoculum.  Identical sequences share a single Genome instance (via the HashMap).
+            Map<Sequence,Genome> seqmap = new HashMap<Sequence,Genome>();
             ancestors = new Genome[inoculum.size()];
             for (int i = 0; i < ancestors.length; i++) {
-                Sequence sequence = inoculum.get(i);
-                ancestors[i] = genePool.createGenome(sequence);
+                Sequence s = inoculum.get(i);
+                Genome g = seqmap.get(s);
+                if (g == null) {
+                    g = genePool.createGenome(s);
+                    seqmap.put(s, g);
+                }
+                ancestors[i] = g;
             }
         } else {
             throw new NotImplementedException();
@@ -68,7 +77,17 @@ public abstract class Population {
             // ancestors[0] = genePool.createGenome(sequence);
         }
 
-        if (ancestors.length > 1) {
+        if (inoculum.size() <= initialPopulationSize) {
+            // Allow experimenting with deterministic initial populations.
+            // If the inoculum is the same size or greater than the population,
+            // use the supplied inoculum as the complete population without any random selection.
+            for (int i = 0; i < initialPopulationSize; i++) {
+                Genome ancestor = ancestors[i];
+                currentGeneration.add(new Virus(ancestor, null));
+                lastGeneration.add(new Virus());
+                ancestor.incrementFrequency();
+            }
+        } else if (ancestors.length > 1) {
             for (int i = 0; i < initialPopulationSize; i++) {
                 Genome ancestor = ancestors[Random.nextInt(0, ancestors.length - 1)];
                 currentGeneration.add(new Virus(ancestor, null));


### PR DESCRIPTION
This PR affects only configurations that supply multiple sequences in the `<genome>` section of a SANTA config file, e.g. 
```
    <genome>
      <length>9</length>
      <sequences>
        GAAAAAGAG
        GAAGAAGAG
      </sequences>
    </genome>
```
Unfortunately none of the config files in `examples/` demonstrate this feature.  There were some limitations and subtle bugs affecting exposure- and frequency-dependent fitness when the population was initialized with multiple sequences.

* When initializing a population from multiple sequences, identical
  sequences will share a single genome instance, and the genome's frequency
  will accurately reflect the number of viruses created from that genome.
  This fixes frequency and exposure dependent fitness
  functions when populations are initialized from multi-sequence pools
  in the config file.

* When the number of sequences supplied in the <sequences> element equals or
  exceeds the <populationSize>, no randomization will occur and the
  initial population will be completely determined by the <sequences>
  element.  This allows a config file to precisely specify a diverse
  initial population.  Fixes #24

* add Java boilerplate to SimpleSequence so instances can be used as
  keys in HashMaps.