### PR TITLE
Bug/nexus export

### DIFF
--- a/src/santa/simulator/samplers/TreeSampler.java
+++ b/src/santa/simulator/samplers/TreeSampler.java
@@ -118,6 +118,7 @@ public class TreeSampler implements Sampler {
 						+ "NEXUS-format trees must share a single set of tip labels across all trees.\n"
 						+ "It is best to avoid using '%g' or '%r'in the the NEXUS tip labels of yourt SANTA config file.\n";
 					System.err.print(msg);
+					throw new RuntimeException("Cannot use variable tip labels");
 				} else {
 					throw e;
 				}

--- a/src/santa/simulator/samplers/TreeSampler.java
+++ b/src/santa/simulator/samplers/TreeSampler.java
@@ -107,12 +107,23 @@ public class TreeSampler implements Sampler {
 	}
 
 	public void cleanUp() {
-		try {
-			if (trees.size() > 0) {
+		if (trees.size() > 0) {
+			try {
 				exporter.exportTrees(trees);
+			} catch (IllegalArgumentException e) {
+				// Catch an exception thrown by the JEBL library
+				// when NEXUS tip labels differ across trees.
+				if (format == TreeSampler.Format.NEXUS) {
+					String msg = "Error: Cannot output NEXUS formatted trees.\n"
+						+ "NEXUS-format trees must share a single set of tip labels across all trees.\n"
+						+ "It is best to avoid using '%g' or '%r'in the the NEXUS tip labels of yourt SANTA config file.\n";
+					System.err.print(msg);
+				} else {
+					throw e;
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
 			}
-		} catch (IOException e) {
-			e.printStackTrace();
 		}
 
 		destination.close();

--- a/test/santa/simulator/samplers/.gitignore
+++ b/test/santa/simulator/samplers/.gitignore
@@ -1,0 +1,3 @@
+/TreeSamplerTest.class
+/XXXTest.class
+/TestSuite.class

--- a/test/santa/simulator/samplers/TreeSamplerTest.java
+++ b/test/santa/simulator/samplers/TreeSamplerTest.java
@@ -1,0 +1,71 @@
+package santa.simulator.samplers;
+
+import santa.simulator.genomes.GenomeDescription;
+import santa.simulator.genomes.Sequence;
+import santa.simulator.genomes.SimpleSequence;
+import santa.simulator.genomes.Feature;
+import santa.simulator.phylogeny.Phylogeny;
+import santa.simulator.fitness.FrequencyDependentFitnessFactor;
+
+import santa.simulator.population.Population;
+import santa.simulator.population.StaticPopulation;
+import santa.simulator.genomes.GenePool;
+import santa.simulator.genomes.SimpleGenePool;
+
+import static org.junit.Assert.*;
+
+import org.junit.BeforeClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.util.*;
+
+
+public class TreeSamplerTest {
+	static GenePool pool;
+	static Phylogeny phy;
+	static Population pop;
+
+	@BeforeClass
+	public static void IniitializeGenomeDescriptor() throws Exception {
+		List<Sequence> sequences = new ArrayList<Sequence>();
+		Sequence seq = new SimpleSequence("aaaaCCCCCcCCCCggTTTTTTaa");
+		// 								   012345678901234567890123
+		sequences.add(seq);
+		
+		List<Feature> features = new ArrayList<Feature>();
+		GenomeDescription.setDescription(seq.getLength(), features, sequences);
+
+		// Initialize a population to sample from
+		int populationSize = 100;
+		pool = new SimpleGenePool();
+		phy = new Phylogeny(populationSize);
+		pop = new StaticPopulation(populationSize, pool, null, phy);
+		Sequence founder = new SimpleSequence("aaaaCCCCCcCCCCggTTTTTTaa");
+		List<Sequence> inoculum = new ArrayList<Sequence>();
+		inoculum.add(founder);
+		pop.initialize(inoculum, populationSize);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		assertNotNull("Expected GenomeDescription class to be initialized.", GenomeDescription.root);
+	}
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void TestBadNexusExport() {
+		TreeSampler ts = new TreeSampler(10, null, TreeSampler.Format.NEXUS, "virus_%g_%s", "treesample.nex");
+		ts.initialize(1);
+		ts.sample(0, pop);
+		ts.sample(1, pop);
+
+		thrown.expect(RuntimeException.class);
+		thrown.expectMessage("Cannot use variable tip labels");
+		ts.cleanUp();
+	}
+}


### PR DESCRIPTION
Issue sensible errors when exporting NEXUS trees.
* resolves issue #3

* The export code in the JEBL library throws an exception if multple trees are exported in NEXUS if those trees don't all share the same tip labels.  The default tip label configured by SANTA  is 'label_%r_%g' which make it likely the user will be confronted with this confusing exception.  This PR catches the exception thrown by JEBL and prints an informative error.

* Also add a unit test to confirm the expected behavior when bad tip labels are chosen for NEXUS export.

