### PR TITLE
Add support for label to export sample fitness in alignment FASTAs

### DIFF
--- a/src/santa/simulator/samplers/AlignmentSampler.java
+++ b/src/santa/simulator/samplers/AlignmentSampler.java
@@ -44,7 +44,7 @@ public class AlignmentSampler implements Sampler {
      * @param consensus   write the consensus sequence of the sample rather than writing the sample ?
      * @param schedule    amount of sequences to sample at irregular intervals
      * @param format      format
-     * @param label       label with possible %g, %s and %t variables
+     * @param label       label with possible %g, %s, %t, and %f variables
      * @param fileName    name of the file to write the samples
      */
     public AlignmentSampler(Feature feature, Set<Integer> sites, int sampleSize, boolean consensus,
@@ -69,7 +69,7 @@ public class AlignmentSampler implements Sampler {
     public void initialize(int replicate) {
 
         this.replicate = replicate;
-        String fName = substituteVariables(fileName, 0, 0);
+        String fName = substituteVariables(fileName, 0, 0, 0.0);
 
         try {
             destination = new PrintStream(fName);
@@ -96,10 +96,11 @@ public class AlignmentSampler implements Sampler {
         }
     }
 
-    private String substituteVariables(String name, int generation, int seq) {
+    private String substituteVariables(String name, int generation, int seq, double fitness) {
         String result = name.replaceAll("%r", String.valueOf(replicate+1));
         result = result.replaceAll("%g", String.valueOf(generation));
         result = result.replaceAll("%s", String.valueOf(seq));
+        result = result.replaceAll("%f", String.valueOf(fitness));
         return result;
     }
 
@@ -165,14 +166,14 @@ public class AlignmentSampler implements Sampler {
 
     private void writeNexusFormat(int generation, Virus[] sample) {
         if (consensus) {
-            String l = substituteVariables(label, generation, 0);
+            String l = substituteVariables(label, generation, 0, 0.0);
 
             destination.print(l + "\t");
             destination.println(computeConsensus(sample));
         } else {
             int i = 1;
             for (Virus virus : sample) {
-                String l = substituteVariables(label, generation, i);
+                String l = substituteVariables(label, generation, i, virus.getFitness());
 
                 destination.print(l + "\t");
 
@@ -230,7 +231,7 @@ public class AlignmentSampler implements Sampler {
 
     private void writeFastaFormat(int generation, Virus[] sample) {
         if (consensus) {
-            String l = substituteVariables(label, generation, 0);
+            String l = substituteVariables(label, generation, 0, 0.0);
 
             destination.println(">" + l);
             destination.println(computeConsensus(sample));
@@ -238,7 +239,7 @@ public class AlignmentSampler implements Sampler {
             int i = 1;
 
             for (Virus virus : sample) {
-                String l = substituteVariables(label, generation, i);
+                String l = substituteVariables(label, generation, i, virus.getFitness());
 
                 destination.println(">" + l);
                 destination.println(virus.getGenome().getSequence().getNucleotides());
@@ -254,7 +255,7 @@ public class AlignmentSampler implements Sampler {
         destination.println("<!-- Generation = " + generation + " -->");
         int i = 1;
         for (Virus virus : sample) {
-            String l = substituteVariables(label, generation, i);
+            String l = substituteVariables(label, generation, i, virus.getFitness());
             destination.println("\t<sequence label=\"" + l+ "\">");
             destination.println("\t\t" + virus.getGenome().getSequence().getNucleotides());
             destination.println("\t</sequence>");


### PR DESCRIPTION
Adds a "%f" placeholder to allow users to emit the fitness per sample in alignment sampler outputs. This fitness value is useful as a positive control for fitness models based on simulated populations. An example configuration section looks like this:

```xml
    <samplingSchedule>
      <sampler>
        <atFrequency>4</atFrequency>
        <fileName>simulated_HA_sequences.fasta</fileName>
        <alignment>
          <sampleSize>10</sampleSize>
          <format>FASTA</format>
          <label>sample_%g_%s|%g|%f</label>
        </alignment>
      </sampler>
    </samplingSchedule>
```

And the first couple lines of the resulting FASTA output look like this:

```
>sample_4_1|4|0.9624923000307998
ATGAAGACTATCATTGCTTTGAGCTACATTTTATG
```

Note that this implementation emits a fitness of zero for consensus sequences. It might be more reasonable to emit the average fitness of the sample instead. I wasn't able to get the consensus outputs working for the alignment sampler, though, so this output remains untested.

If there is a better way to emit the fitness per sample, I am also happy to reimplement with that approach. Either way, thank you for providing this excellent software!